### PR TITLE
Remove erroneous normalization of flow velocity by samples

### DIFF
--- a/azplugins/flow.py
+++ b/azplugins/flow.py
@@ -754,6 +754,6 @@ class FlowProfiler:
             raise RuntimeError('Flow profile only defined on root rank')
 
         if self.samples > 0:
-            return np.divide(self._velocity, self._counts, out=np.zeros(self.bins), where=self._counts > 0)/self.samples
+            return np.divide(self._velocity, self._counts, out=np.zeros(self.bins), where=self._counts > 0)
         else:
             return np.zeros(self.bins)


### PR DESCRIPTION
Removes extra factor of `self.samples` when averaging velocities, which caused the reported velocities to be too low.