### PR TITLE
Update copyright to 2021

### DIFF
--- a/CMake/find_hoomd.py
+++ b/CMake/find_hoomd.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
 
 # Maintainer: mphoward

--- a/CMake/parse_version.py
+++ b/CMake/parse_version.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
 
 # Maintainer: mphoward

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2018-2020, Michael P. Howard
+Copyright (c) 2021, Auburn University
 
 All rights reserved.
 

--- a/azplugins/AnisoPairEvaluator.h
+++ b/azplugins/AnisoPairEvaluator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file AnisoPairEvaluator.h

--- a/azplugins/AnisoPairEvaluatorTwoPatchMorse.h
+++ b/azplugins/AnisoPairEvaluatorTwoPatchMorse.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file AnisoPairEvaluatorTwoPatchMorse.h

--- a/azplugins/AnisoPairPotentialTwoPatchMorse.cu
+++ b/azplugins/AnisoPairPotentialTwoPatchMorse.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "AnisoPairPotentials.cuh"
 

--- a/azplugins/AnisoPairPotentials.cuh
+++ b/azplugins/AnisoPairPotentials.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file AnisoPairPotentials.cuh

--- a/azplugins/AnisoPairPotentials.h
+++ b/azplugins/AnisoPairPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file AnisoPairPotentials.h

--- a/azplugins/BondEvaluatorDoubleWell.h
+++ b/azplugins/BondEvaluatorDoubleWell.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*! \file BondEvaluatorDoubleWell.h
     \brief Defines the bond evaluator class for a double well potential

--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*! \file BondEvaluatorFENE.h
     \brief Defines the bond evaluator class for a FENE potential

--- a/azplugins/BondEvaluatorFENEAsh24.h
+++ b/azplugins/BondEvaluatorFENEAsh24.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*! \file BondEvaluatorFENEAsh24.h
     \brief Defines the bond evaluator class for a FENE-24-48 potential

--- a/azplugins/BondPotentials.cu
+++ b/azplugins/BondPotentials.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file BondPotentials.cu

--- a/azplugins/BondPotentials.cuh
+++ b/azplugins/BondPotentials.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BondPotentials.cuh

--- a/azplugins/BondPotentials.h
+++ b/azplugins/BondPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file BondPotentials.h

--- a/azplugins/BounceBackGeometry.cc
+++ b/azplugins/BounceBackGeometry.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackGeometry.cc

--- a/azplugins/BounceBackGeometry.h
+++ b/azplugins/BounceBackGeometry.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackGeometry.h

--- a/azplugins/BounceBackNVE.h
+++ b/azplugins/BounceBackNVE.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackNVE.h

--- a/azplugins/BounceBackNVEGPU.cu
+++ b/azplugins/BounceBackNVEGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackNVEGPU.cu

--- a/azplugins/BounceBackNVEGPU.cuh
+++ b/azplugins/BounceBackNVEGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackNVEGPU.cuh

--- a/azplugins/BounceBackNVEGPU.h
+++ b/azplugins/BounceBackNVEGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file BounceBackNVEGPU.h

--- a/azplugins/CMakeLists.txt
+++ b/azplugins/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / All developers are free to add new source files as needed
 
 set(COMPONENT_NAME azplugins)
 

--- a/azplugins/DPDEvaluatorGeneralWeight.h
+++ b/azplugins/DPDEvaluatorGeneralWeight.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file DPDEvaluatorGeneralWeight.h

--- a/azplugins/DPDPotentialGeneralWeight.cu
+++ b/azplugins/DPDPotentialGeneralWeight.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "DPDPotentials.cuh"
 

--- a/azplugins/DPDPotentials.cuh
+++ b/azplugins/DPDPotentials.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file DPDPotentials.cuh

--- a/azplugins/DPDPotentials.h
+++ b/azplugins/DPDPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file DPDPotentials.h

--- a/azplugins/FlowFields.h
+++ b/azplugins/FlowFields.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParabolicFlow.h

--- a/azplugins/HOOMDAPI.h
+++ b/azplugins/HOOMDAPI.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file HOOMDAPI.h

--- a/azplugins/ImplicitDropletEvaporator.cc
+++ b/azplugins/ImplicitDropletEvaporator.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporator.cc

--- a/azplugins/ImplicitDropletEvaporator.h
+++ b/azplugins/ImplicitDropletEvaporator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporator.h

--- a/azplugins/ImplicitDropletEvaporatorGPU.cc
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporatorGPU.cc

--- a/azplugins/ImplicitDropletEvaporatorGPU.cu
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporatorGPU.cu

--- a/azplugins/ImplicitDropletEvaporatorGPU.cuh
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporatorGPU.cuh

--- a/azplugins/ImplicitDropletEvaporatorGPU.h
+++ b/azplugins/ImplicitDropletEvaporatorGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitDropletEvaporatorGPU.h

--- a/azplugins/ImplicitEvaporator.cc
+++ b/azplugins/ImplicitEvaporator.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitEvaporator.cc

--- a/azplugins/ImplicitEvaporator.h
+++ b/azplugins/ImplicitEvaporator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitEvaporator.h

--- a/azplugins/ImplicitEvaporatorGPU.cc
+++ b/azplugins/ImplicitEvaporatorGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitEvaporatorGPU.cc

--- a/azplugins/ImplicitEvaporatorGPU.h
+++ b/azplugins/ImplicitEvaporatorGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitEvaporatorGPU.h

--- a/azplugins/ImplicitPlaneEvaporator.cc
+++ b/azplugins/ImplicitPlaneEvaporator.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporator.cc

--- a/azplugins/ImplicitPlaneEvaporator.h
+++ b/azplugins/ImplicitPlaneEvaporator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporator.h

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cc
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporatorGPU.cc

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cu
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporatorGPU.cu

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cuh
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporatorGPU.cuh

--- a/azplugins/ImplicitPlaneEvaporatorGPU.h
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitPlaneEvaporatorGPU.h

--- a/azplugins/MPCDReversePerturbationFlow.cc
+++ b/azplugins/MPCDReversePerturbationFlow.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePertubationFlow.cc

--- a/azplugins/MPCDReversePerturbationFlow.h
+++ b/azplugins/MPCDReversePerturbationFlow.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePerturbationFlow.h

--- a/azplugins/MPCDReversePerturbationFlowGPU.cc
+++ b/azplugins/MPCDReversePerturbationFlowGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePerturbationFlowGPU.cc

--- a/azplugins/MPCDReversePerturbationFlowGPU.cu
+++ b/azplugins/MPCDReversePerturbationFlowGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePerturbationFlowGPU.cu

--- a/azplugins/MPCDReversePerturbationFlowGPU.cuh
+++ b/azplugins/MPCDReversePerturbationFlowGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePerturbationFlowGPU.cuh

--- a/azplugins/MPCDReversePerturbationFlowGPU.h
+++ b/azplugins/MPCDReversePerturbationFlowGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file MPCDReversePerturbationFlowGPU.h

--- a/azplugins/OrientationRestraintCompute.cc
+++ b/azplugins/OrientationRestraintCompute.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file OrientationRestraintCompute.cc

--- a/azplugins/OrientationRestraintCompute.h
+++ b/azplugins/OrientationRestraintCompute.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*! \file OrientationRestraintCompute.h
     \brief Declares a class for computing orientation restraining forces

--- a/azplugins/OrientationRestraintComputeGPU.cc
+++ b/azplugins/OrientationRestraintComputeGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file OrientationRestraintCompute.cc

--- a/azplugins/OrientationRestraintComputeGPU.cu
+++ b/azplugins/OrientationRestraintComputeGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file OrientationRestraintComputeGPU.cu

--- a/azplugins/OrientationRestraintComputeGPU.cuh
+++ b/azplugins/OrientationRestraintComputeGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file OrientationRestraintComputeGPU.cuh

--- a/azplugins/OrientationRestraintComputeGPU.h
+++ b/azplugins/OrientationRestraintComputeGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file OrientationRestraintComputeGPU.h

--- a/azplugins/PairEvaluator.h
+++ b/azplugins/PairEvaluator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file PairEvaluator.h

--- a/azplugins/PairEvaluatorAshbaugh.h
+++ b/azplugins/PairEvaluatorAshbaugh.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file PairEvaluatorAshbaugh.h

--- a/azplugins/PairEvaluatorAshbaugh24.h
+++ b/azplugins/PairEvaluatorAshbaugh24.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file PairEvaluatorAshbaugh24.h

--- a/azplugins/PairEvaluatorColloid.h
+++ b/azplugins/PairEvaluatorColloid.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file PairEvaluatorColloid.h

--- a/azplugins/PairEvaluatorHertz.h
+++ b/azplugins/PairEvaluatorHertz.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: arjunsg2
 
 /*!
  * \file PairEvaluatorHertz.h

--- a/azplugins/PairEvaluatorLJ124.h
+++ b/azplugins/PairEvaluatorLJ124.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: sjiao
 
 /*!
  * \file PairEvaluatorLJ124.h

--- a/azplugins/PairEvaluatorLJ96.h
+++ b/azplugins/PairEvaluatorLJ96.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: sjiao
 
 /*!
  * \file PairEvaluatorLJ96.h

--- a/azplugins/PairEvaluatorShiftedLJ.h
+++ b/azplugins/PairEvaluatorShiftedLJ.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file PairEvaluatorShiftedLJ.h

--- a/azplugins/PairEvaluatorSpline.h
+++ b/azplugins/PairEvaluatorSpline.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file PairEvaluatorSpline.h

--- a/azplugins/PairPotentialAshbaugh.cu
+++ b/azplugins/PairPotentialAshbaugh.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialAshbaugh24.cu
+++ b/azplugins/PairPotentialAshbaugh24.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialColloid.cu
+++ b/azplugins/PairPotentialColloid.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialHertz.cu
+++ b/azplugins/PairPotentialHertz.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: arjunsg2
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialLJ124.cu
+++ b/azplugins/PairPotentialLJ124.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialLJ96.cu
+++ b/azplugins/PairPotentialLJ96.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialShiftedLJ.cu
+++ b/azplugins/PairPotentialShiftedLJ.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentialSpline.cu
+++ b/azplugins/PairPotentialSpline.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "PairPotentials.cuh"
 

--- a/azplugins/PairPotentials.cuh
+++ b/azplugins/PairPotentials.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file PairPotentials.cuh

--- a/azplugins/PairPotentials.h
+++ b/azplugins/PairPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file PairPotentials.h

--- a/azplugins/ParticleEvaporator.cc
+++ b/azplugins/ParticleEvaporator.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporator.h

--- a/azplugins/ParticleEvaporator.h
+++ b/azplugins/ParticleEvaporator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporator.h

--- a/azplugins/ParticleEvaporatorGPU.cc
+++ b/azplugins/ParticleEvaporatorGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporatorGPU.cc

--- a/azplugins/ParticleEvaporatorGPU.cu
+++ b/azplugins/ParticleEvaporatorGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporatorGPU.cu

--- a/azplugins/ParticleEvaporatorGPU.cuh
+++ b/azplugins/ParticleEvaporatorGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporatorGPU.cuh

--- a/azplugins/ParticleEvaporatorGPU.h
+++ b/azplugins/ParticleEvaporatorGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ParticleEvaporatorGPU.h

--- a/azplugins/PositionRestraintCompute.cc
+++ b/azplugins/PositionRestraintCompute.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintCompute.cc

--- a/azplugins/PositionRestraintCompute.h
+++ b/azplugins/PositionRestraintCompute.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintCompute.h

--- a/azplugins/PositionRestraintComputeGPU.cc
+++ b/azplugins/PositionRestraintComputeGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintCompute.cc

--- a/azplugins/PositionRestraintComputeGPU.cu
+++ b/azplugins/PositionRestraintComputeGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintComputeGPU.cu

--- a/azplugins/PositionRestraintComputeGPU.cuh
+++ b/azplugins/PositionRestraintComputeGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintComputeGPU.cuh

--- a/azplugins/PositionRestraintComputeGPU.h
+++ b/azplugins/PositionRestraintComputeGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: wes_reinhart
 
 /*!
  * \file PositionRestraintComputeGPU.h

--- a/azplugins/RDFAnalyzer.cc
+++ b/azplugins/RDFAnalyzer.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RDFAnalyzer.cc

--- a/azplugins/RDFAnalyzer.h
+++ b/azplugins/RDFAnalyzer.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RDFAnalyzer.h

--- a/azplugins/RDFAnalyzerGPU.cc
+++ b/azplugins/RDFAnalyzerGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RDFAnalyzerGPU.cc

--- a/azplugins/RDFAnalyzerGPU.cu
+++ b/azplugins/RDFAnalyzerGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file ImplicitEvaporatorGPU.cu

--- a/azplugins/RDFAnalyzerGPU.cuh
+++ b/azplugins/RDFAnalyzerGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RDFAnalyzerGPU.cuh

--- a/azplugins/RDFAnalyzerGPU.h
+++ b/azplugins/RDFAnalyzerGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RDFAnalyzerGPU.h

--- a/azplugins/RNGIdentifiers.h
+++ b/azplugins/RNGIdentifiers.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file RNGIdentifier.h

--- a/azplugins/ReversePerturbationFlow.cc
+++ b/azplugins/ReversePerturbationFlow.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlow.cc

--- a/azplugins/ReversePerturbationFlow.h
+++ b/azplugins/ReversePerturbationFlow.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlow.h

--- a/azplugins/ReversePerturbationFlowGPU.cc
+++ b/azplugins/ReversePerturbationFlowGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlowGPU.cc

--- a/azplugins/ReversePerturbationFlowGPU.cu
+++ b/azplugins/ReversePerturbationFlowGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlowGPU.cu

--- a/azplugins/ReversePerturbationFlowGPU.cuh
+++ b/azplugins/ReversePerturbationFlowGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlowGPU.cuh

--- a/azplugins/ReversePerturbationFlowGPU.h
+++ b/azplugins/ReversePerturbationFlowGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationFlowGPU.h

--- a/azplugins/ReversePerturbationUtilities.h
+++ b/azplugins/ReversePerturbationUtilities.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: astatt
 
 /*!
  * \file ReversePerturbationUtilities.h

--- a/azplugins/SpecialPairEvaluator.h
+++ b/azplugins/SpecialPairEvaluator.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: sjiao
 
 /*!
  * \file SpecialPairEvaluator.h

--- a/azplugins/SpecialPairPotentials.cu
+++ b/azplugins/SpecialPairPotentials.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file SpecialPairPotentials.cu

--- a/azplugins/SpecialPairPotentials.cuh
+++ b/azplugins/SpecialPairPotentials.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file SpecialPairPotentials.cuh

--- a/azplugins/SpecialPairPotentials.h
+++ b/azplugins/SpecialPairPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file SpecialPairPotentials.h

--- a/azplugins/TwoStepBrownianFlow.h
+++ b/azplugins/TwoStepBrownianFlow.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepBrownianFlow.h

--- a/azplugins/TwoStepBrownianFlowGPU.cu
+++ b/azplugins/TwoStepBrownianFlowGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepBrownianFlowGPU.cu

--- a/azplugins/TwoStepBrownianFlowGPU.cuh
+++ b/azplugins/TwoStepBrownianFlowGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepBrownianFlowGPU.cuh

--- a/azplugins/TwoStepBrownianFlowGPU.h
+++ b/azplugins/TwoStepBrownianFlowGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepBrownianFlowGPU.h

--- a/azplugins/TwoStepLangevinFlow.h
+++ b/azplugins/TwoStepLangevinFlow.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepLangevinFlow.h

--- a/azplugins/TwoStepLangevinFlowGPU.cu
+++ b/azplugins/TwoStepLangevinFlowGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepLangevinFlowGPU.cu

--- a/azplugins/TwoStepLangevinFlowGPU.cuh
+++ b/azplugins/TwoStepLangevinFlowGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepLangevinFlowGPU.cuh

--- a/azplugins/TwoStepLangevinFlowGPU.h
+++ b/azplugins/TwoStepLangevinFlowGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TwoStepLangevinFlowGPU.h

--- a/azplugins/TypeUpdater.cc
+++ b/azplugins/TypeUpdater.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdater.cc

--- a/azplugins/TypeUpdater.h
+++ b/azplugins/TypeUpdater.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdater.h

--- a/azplugins/TypeUpdaterGPU.cc
+++ b/azplugins/TypeUpdaterGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdaterGPU.cc

--- a/azplugins/TypeUpdaterGPU.cu
+++ b/azplugins/TypeUpdaterGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdaterGPU.cu

--- a/azplugins/TypeUpdaterGPU.cuh
+++ b/azplugins/TypeUpdaterGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdaterGPU.cuh

--- a/azplugins/TypeUpdaterGPU.h
+++ b/azplugins/TypeUpdaterGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file TypeUpdaterGPU.h

--- a/azplugins/VariantSphereArea.cc
+++ b/azplugins/VariantSphereArea.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file VariantSphereArea.cc

--- a/azplugins/VariantSphereArea.h
+++ b/azplugins/VariantSphereArea.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file VariantSphereArea.h

--- a/azplugins/WallEvaluatorColloid.h
+++ b/azplugins/WallEvaluatorColloid.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file WallEvaluatorColloid.h

--- a/azplugins/WallEvaluatorLJ93.h
+++ b/azplugins/WallEvaluatorLJ93.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file WallEvaluatorLJ93.h

--- a/azplugins/WallPotentials.cu
+++ b/azplugins/WallPotentials.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file WallPotentials.cu

--- a/azplugins/WallPotentials.h
+++ b/azplugins/WallPotentials.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional potentials
 
 /*!
  * \file WallPotentials.h

--- a/azplugins/WallRestraintCompute.cc
+++ b/azplugins/WallRestraintCompute.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "WallRestraintCompute.h"
 

--- a/azplugins/WallRestraintCompute.h
+++ b/azplugins/WallRestraintCompute.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*! \file WallRestraintCompute.h
  *  \brief Computes harmonic restraint forces relative to a WallData object

--- a/azplugins/WallRestraintComputeGPU.cc
+++ b/azplugins/WallRestraintComputeGPU.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "WallRestraintComputeGPU.h"
 

--- a/azplugins/WallRestraintComputeGPU.cu
+++ b/azplugins/WallRestraintComputeGPU.cu
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #include "WallRestraintComputeGPU.cuh"
 

--- a/azplugins/WallRestraintComputeGPU.cuh
+++ b/azplugins/WallRestraintComputeGPU.cuh
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 #ifndef AZPLUGINS_WALL_RESTRAINT_COMPUTE_GPU_CUH_
 #define AZPLUGINS_WALL_RESTRAINT_COMPUTE_GPU_CUH_

--- a/azplugins/WallRestraintComputeGPU.h
+++ b/azplugins/WallRestraintComputeGPU.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*! \file WallRestraintComputeGPU.h
  *  \brief Computes harmonic restraint forces relative to a plane, on the GPU

--- a/azplugins/__init__.py
+++ b/azplugins/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
 
 # Maintainer: mphoward / All developers are free to add new modules
@@ -25,4 +26,4 @@ from . import update
 from . import variant
 from . import wall
 
-__version__ = '0.10.1'
+__version__ = '0.10.2'

--- a/azplugins/_azplugins.py
+++ b/azplugins/_azplugins.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 """This file is only for mock imports during doc generation."""

--- a/azplugins/analyze.py
+++ b/azplugins/analyze.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional analyzers
 
 import numpy
 import hoomd

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt / Everyone is free to add additional potentials
 
 import math
 

--- a/azplugins/dpd.py
+++ b/azplugins/dpd.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional potentials
 
 import hoomd
 from hoomd import _hoomd

--- a/azplugins/evaporate.py
+++ b/azplugins/evaporate.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 

--- a/azplugins/flow.py
+++ b/azplugins/flow.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt / mphoward
 
 import numpy as np
 import hoomd

--- a/azplugins/integrate.py
+++ b/azplugins/integrate.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional potentials
 
 import hoomd
 from hoomd.mpcd import _mpcd

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward / Everyone is free to add additional objects
 
 /*!
  * \file module.cc

--- a/azplugins/mpcd.py
+++ b/azplugins/mpcd.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt / Everyone is free to add additional methods for mpcd
 
 import hoomd
 

--- a/azplugins/pair.py
+++ b/azplugins/pair.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional potentials
 
 import math
 

--- a/azplugins/restrain.py
+++ b/azplugins/restrain.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: wes_reinhart
 
 r""" Restraining forces.
 

--- a/azplugins/special_pair.py
+++ b/azplugins/special_pair.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional potentials
 
 import math
 

--- a/azplugins/test-py/CMakeLists.txt
+++ b/azplugins/test-py/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
 
 set(TEST_LIST_CPU

--- a/azplugins/test-py/test_analyze_rdf.py
+++ b/azplugins/test-py/test_analyze_rdf.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_bond_double_well.py
+++ b/azplugins/test-py/test_bond_double_well.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_bond_fene24.py
+++ b/azplugins/test-py/test_bond_fene24.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_dpd_general.py
+++ b/azplugins/test-py/test_dpd_general.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_evaporate_implicit.py
+++ b/azplugins/test-py/test_evaporate_implicit.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_evaporate_particles.py
+++ b/azplugins/test-py/test_evaporate_particles.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_flow_brownian.py
+++ b/azplugins/test-py/test_flow_brownian.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 hoomd.context.initialize()

--- a/azplugins/test-py/test_flow_constant.py
+++ b/azplugins/test-py/test_flow_constant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 hoomd.context.initialize()

--- a/azplugins/test-py/test_flow_flow_profiler.py
+++ b/azplugins/test-py/test_flow_flow_profiler.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_flow_langevin.py
+++ b/azplugins/test-py/test_flow_langevin.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 hoomd.context.initialize()

--- a/azplugins/test-py/test_flow_parabolic.py
+++ b/azplugins/test-py/test_flow_parabolic.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 hoomd.context.initialize()

--- a/azplugins/test-py/test_flow_quiescent.py
+++ b/azplugins/test-py/test_flow_quiescent.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 hoomd.context.initialize()

--- a/azplugins/test-py/test_flow_reverse_perturbation.py
+++ b/azplugins/test-py/test_flow_reverse_perturbation.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_integrate_slit.py
+++ b/azplugins/test-py/test_integrate_slit.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_mpcd_reverse_perturbation.py
+++ b/azplugins/test-py/test_mpcd_reverse_perturbation.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_ashbaugh.py
+++ b/azplugins/test-py/test_pair_ashbaugh.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_ashbaugh24.py
+++ b/azplugins/test-py/test_pair_ashbaugh24.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_colloid.py
+++ b/azplugins/test-py/test_pair_colloid.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_hertz.py
+++ b/azplugins/test-py/test_pair_hertz.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: arjunsg2
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_lj124.py
+++ b/azplugins/test-py/test_pair_lj124.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: sjiao
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_lj96.py
+++ b/azplugins/test-py/test_pair_lj96.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: sjiao
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_slj.py
+++ b/azplugins/test-py/test_pair_slj.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_spline.py
+++ b/azplugins/test-py/test_pair_spline.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: astatt
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_pair_two_patch_morse.py
+++ b/azplugins/test-py/test_pair_two_patch_morse.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: wes_reinhart
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_restrain_cylinder.py
+++ b/azplugins/test-py/test_restrain_cylinder.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import numpy as np
 

--- a/azplugins/test-py/test_restrain_orientation.py
+++ b/azplugins/test-py/test_restrain_orientation.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: wes_reinhart
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_restrain_plane.py
+++ b/azplugins/test-py/test_restrain_plane.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import numpy as np
 

--- a/azplugins/test-py/test_restrain_position.py
+++ b/azplugins/test-py/test_restrain_position.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: wes_reinhart
 
 import hoomd
 import hoomd

--- a/azplugins/test-py/test_restrain_sphere.py
+++ b/azplugins/test-py/test_restrain_sphere.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import numpy as np
 

--- a/azplugins/test-py/test_special_pair_lj96.py
+++ b/azplugins/test-py/test_special_pair_lj96.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: sjiao
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_update_type.py
+++ b/azplugins/test-py/test_update_type.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_variant_sphere_area.py
+++ b/azplugins/test-py/test_variant_sphere_area.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_wall_colloid.py
+++ b/azplugins/test-py/test_wall_colloid.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test-py/test_wall_lj93.py
+++ b/azplugins/test-py/test_wall_lj93.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward
 
 import hoomd
 from hoomd import md

--- a/azplugins/test/CMakeLists.txt
+++ b/azplugins/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / All developers are free to add unit tests as needed
 
 ###################################
 ## Setup all of the test executables

--- a/azplugins/test/example_test.cc
+++ b/azplugins/test/example_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file example_test.cc

--- a/azplugins/test/upp11_config.h
+++ b/azplugins/test/upp11_config.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021, Auburn University
 // This file is part of the azplugins project, released under the Modified BSD License.
-
-// Maintainer: mphoward
 
 /*!
  * \file upp11_config.h

--- a/azplugins/update.py
+++ b/azplugins/update.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional updaters
 
 import hoomd
 

--- a/azplugins/variant.py
+++ b/azplugins/variant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional variants
 
 import hoomd
 

--- a/azplugins/wall.py
+++ b/azplugins/wall.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
 # This file is part of the azplugins project, released under the Modified BSD License.
-
-# Maintainer: mphoward / Everyone is free to add additional potentials
 
 import hoomd
 from hoomd import _hoomd

--- a/check_format.sh
+++ b/check_format.sh
@@ -32,7 +32,7 @@ do
     fi
 
     # check for tabs
-    N=$(grep -P -c "\t" $f)
+    N=$(grep -c "\t" $f)
     if [ "$N" -gt "0" ]
     then
         echo "Tabs in $f:"
@@ -58,20 +58,12 @@ do
     skip_file=$(contains "$skip" "$filename")
     if [ "$skip_file" -eq "0" ]
     then
-        N=$(grep -c "Copyright (c) 2018-2020, Michael P. Howard" $f)
+        N=$(grep -c "Copyright (c) 2021, Auburn University" $f)
         if [ "$N" -ne "1" ]
         then
             echo "Copyright notice incorrect in $f"
             RESULT=1
         fi
-    fi
-
-    # check for maintainer line
-    N=$(grep -c "Maintainer:" $f)
-    if [ "$N" -ne "1" ]
-    then
-        echo "Missing maintainer in $f"
-        RESULT=1
     fi
 
 done

--- a/check_format.sh
+++ b/check_format.sh
@@ -32,7 +32,7 @@ do
     fi
 
     # check for tabs
-    N=$(grep -c "\t" $f)
+    N=$(grep -P -c "\t" $f)
     if [ "$N" -gt "0" ]
     then
         echo "Tabs in $f:"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021, Auburn University
+# This file is part of the azplugins project, released under the Modified BSD License.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -14,10 +18,10 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'azplugins'
-copyright = '2018-2020, Michael P. Howard'
+copyright = '2018-2021, Auburn University'
 author = 'Michael P. Howard'
-version = '0.10.1'
-release = '0.10.1'
+version = '0.10.2'
+release = '0.10.2'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Per discussion with our legal office, this needs to read "Copyright (c) 2021, Auburn University".

I am also removing all the maintainers from each file, as there isn't much active maintenance needed, and we can patch as needed.