### PR TITLE
Add shift parameter to FENE bond potential

### DIFF
--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -17,8 +17,10 @@
 
 #ifdef NVCC
 #define DEVICE __device__
+#define HOSTDEVICE __host__ __device__
 #else
 #define DEVICE
+#define HOSTDEVICE
 #endif
 
 namespace azplugins
@@ -165,5 +167,5 @@ class BondEvaluatorFENE
 } // end namespace azplugins
 
 #undef DEVICE
-
+#undef HOSTDEVICE
 #endif // AZPLUGINS_BOND_EVALUATOR_FENE_H_

--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -36,10 +36,10 @@ namespace detail
 
   //! Convenience function for makingfene_bond_params in python
   HOSTDEVICE inline fene_bond_params make_fene_bond_params(Scalar lj1,
-                                                         Scalar lj2,
-                                                         Scalar K,
-                                                         Scalar r_0,
-                                                         Scalar delta)
+                                                           Scalar lj2,
+                                                           Scalar K,
+                                                           Scalar r_0,
+                                                           Scalar delta)
       {
       fene_bond_params p;
       p.lj1 = lj1;
@@ -49,10 +49,6 @@ namespace detail
       p.delta = delta;
       return p;
       }
-
-
-
-
 //! Class for evaluating the FENE bond potential
 /*! The parameters are:
     - \a K (params.x) Stiffness parameter for the force computation
@@ -128,7 +124,7 @@ class BondEvaluatorFENE
                 bond_eng = r6inv * (lj1*r6inv - lj2) + epsilon;
                 }
             // Check if delta is non -zero,if non-zero sqrt of rsq is calculated
-            if (delta!=Scalar(0))
+            if (delta != Scalar(0))
                 {
                 const Scalar r = fast::sqrt(rsq);
                 const Scalar r_red = r - delta;
@@ -163,7 +159,6 @@ class BondEvaluatorFENE
         Scalar lj1;        //!< lj1 parameter
         Scalar lj2;        //!< lj2 parameter
         Scalar delta;      //!< delta parameter in FENE bond
-
     };
 
 } // end namespace detail

--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -49,6 +49,7 @@ namespace detail
       p.delta = delta;
       return p;
       }
+
 //! Class for evaluating the FENE bond potential
 /*! The parameters are:
     - \a K (params.x) Stiffness parameter for the force computation
@@ -63,7 +64,6 @@ class BondEvaluatorFENE
     public:
         //! Define the parameter type used by this bond potential evaluator
         typedef fene_bond_params param_type;
-
 
         //! Constructs the pair potential evaluator
         /*!

--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -75,7 +75,7 @@ class BondEvaluatorFENE
          * \param _params Per type bond parameters of this potential as given above
          */
         DEVICE BondEvaluatorFENE(Scalar _rsq, const param_type& _params)
-            : rsq(_rsq), K(_params.K), r_0(_params.r0), lj1(_params.lj1), lj2(_params.lj2),
+            : rsq(_rsq), K(_params.K), r_0(_params.r_0), lj1(_params.lj1), lj2(_params.lj2),
               delta(_params.delta)
             {
             }

--- a/azplugins/BondEvaluatorFENE.h
+++ b/azplugins/BondEvaluatorFENE.h
@@ -130,14 +130,16 @@ class BondEvaluatorFENE
             // Check if delta is non -zero,if non-zero sqrt of rsq is calculated
             if (delta!=Scalar(0))
                 {
-                const Scalar rsqrt = fast::sqrt(rsq)
-                force_divr += -K*(rsqrt-delta) / (Scalar(1.0) - (rsqrt-delta)*(rsqrt-delta)/(r_0*r_0))/rsqrt;
-                bond_eng += -Scalar(0.5)*K*(r_0*r_0)*log(Scalar(1.0) - (rsqrt-delta)*(rsqrt-delta)/(r_0*r_0));
+                const Scalar r = fast::sqrt(rsq);
+                const Scalar r_red = r - delta;
+
+                force_divr += -K*r_red / (Scalar(1.0) - r_red*r_red/(r_0*r_0))/r;
+                bond_eng += -Scalar(0.5)*K*(r_0*r_0)*fast::log(Scalar(1.0) - r_red*r_red/(r_0*r_0));
                 }
             else
                 {
                 force_divr += -K / (Scalar(1.0) -rsq/(r_0*r_0));
-                bond_eng += -Scalar(0.5)*K*(r_0*r_0)*log(Scalar(1.0) - rsq/(r_0*r_0));
+                bond_eng += -Scalar(0.5)*K*(r_0*r_0)*fast::log(Scalar(1.0) - rsq/(r_0*r_0));
                 }
             return true;
             }

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -124,7 +124,7 @@ class fene(hoomd.md.bond._bond):
     Examples::
 
         fene = azplugins.bond.fene()
-        fene.bond_coeff.set('polymer', k=30.0, r0=1.5, sigma=1.0, epsilon=2.0, delta=2.8)
+        fene.bond_coeff.set('polymer', k=30.0, r0=1.5, sigma=1.0, epsilon=2.0, delta=1.8)
         fene.bond_coeff.set('backbone', k=100.0, r0=1.0, sigma=1.0, epsilon= 2.0, delta=0.0)
 
     """

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -120,7 +120,8 @@ class fene(hoomd.md.bond._bond):
     - :math:`r_0` - size parameter ``r0`` (in distance units)
     - :math:`\varepsilon` - repulsive force strength ``epsilon`` (in energy units)
     - :math:`\sigma` - repulsive force interaction distance ``sigma`` (in distance units)
-    - :math:`\delta` - extra shift parameter for FENE bonds ``delta`` (in distance units)
+    - :math:`\delta` - extra shift parameter for FENE bonds ``delta`` (in distance units),default value of ``delta` is zero
+
     Examples::
 
         fene = azplugins.bond.fene()
@@ -160,9 +161,9 @@ class fene(hoomd.md.bond._bond):
         lj1 = 4.0 * epsilon * math.pow(sigma, 12.0)
         lj2 = 4.0 * epsilon * math.pow(sigma, 6.0)
 
-        #if epsilon==0:
-        #    hoomd.context.msg.error("azplugins.bond.fene(): epsilon must be non-zero.\n")
-        #    raise ValueError('epsilon must be non-zero')
+        if epsilon==0:
+            hoomd.context.msg.error("azplugins.bond.fene(): epsilon must be non-zero.\n")
+            raise ValueError('epsilon must be non-zero')
         if sigma==0:
             hoomd.context.msg.error("azplugins.bond.fene(): sigma must be non-zero.\n")
             raise ValueError('sigma must be non-zero')
@@ -173,7 +174,6 @@ class fene(hoomd.md.bond._bond):
             hoomd.context.msg.error("azplugins.bond.fene(): r0 must be non-zero.\n")
             raise ValueError('r0 must be non-zero')
 
-        #return _hoomd.make_scalar4(k, r0, lj1, lj2)
         return _azplugins.make_fene_bond_params(lj1, lj2,k,r0,delta)
 
 

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -101,7 +101,7 @@ class fene(hoomd.md.bond._bond):
 
     .. math::
 
-        V(r) = - \frac{1}{2} k r_0^2 \ln \left( 1 - \left( \frac{r}{r_0} \right)^2 \right) + V_{\rm WCA}(r)
+        V(r) = - \frac{1}{2} k r_0^2 \ln \left( 1 - \left( \frac{r-\delta}{r_0} \right)^2 \right) + V_{\rm WCA}(r)
 
     where :math:`\vec{r}` is the vector pointing from one particle to the other in the bond.
     The potential :math:`V_{\rm WCA}(r)` is given by:
@@ -120,12 +120,12 @@ class fene(hoomd.md.bond._bond):
     - :math:`r_0` - size parameter ``r0`` (in distance units)
     - :math:`\varepsilon` - repulsive force strength ``epsilon`` (in energy units)
     - :math:`\sigma` - repulsive force interaction distance ``sigma`` (in distance units)
-
+    - :math:`\delta` - extra shift parameter for FENE bonds ``delta`` (in distance units)
     Examples::
 
         fene = azplugins.bond.fene()
-        fene.bond_coeff.set('polymer', k=30.0, r0=1.5, sigma=1.0, epsilon=2.0)
-        fene.bond_coeff.set('backbone', k=100.0, r0=1.0, sigma=1.0, epsilon= 2.0)
+        fene.bond_coeff.set('polymer', k=30.0, r0=1.5, sigma=1.0, epsilon=2.0, delta=2.8)
+        fene.bond_coeff.set('backbone', k=100.0, r0=1.0, sigma=1.0, epsilon= 2.0, delta=0.0)
 
     """
     def __init__(self, name=None):
@@ -149,6 +149,7 @@ class fene(hoomd.md.bond._bond):
 
         # setup the coefficient options
         self.required_coeffs = ['k','r0','epsilon','sigma','delta']
+        self.bond_coeff.set_default_coeff('delta', 0.0)
 
     def process_coeff(self, coeff):
         k = coeff['k']
@@ -159,9 +160,9 @@ class fene(hoomd.md.bond._bond):
         lj1 = 4.0 * epsilon * math.pow(sigma, 12.0)
         lj2 = 4.0 * epsilon * math.pow(sigma, 6.0)
 
-        if epsilon==0:
-            hoomd.context.msg.error("azplugins.bond.fene(): epsilon must be non-zero.\n")
-            raise ValueError('epsilon must be non-zero')
+        #if epsilon==0:
+        #    hoomd.context.msg.error("azplugins.bond.fene(): epsilon must be non-zero.\n")
+        #    raise ValueError('epsilon must be non-zero')
         if sigma==0:
             hoomd.context.msg.error("azplugins.bond.fene(): sigma must be non-zero.\n")
             raise ValueError('sigma must be non-zero')

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -148,13 +148,14 @@ class fene(hoomd.md.bond._bond):
         hoomd.context.current.system.addCompute(self.cpp_force, self.force_name)
 
         # setup the coefficient options
-        self.required_coeffs = ['k','r0','epsilon','sigma']
+        self.required_coeffs = ['k','r0','epsilon','sigma','delta']
 
     def process_coeff(self, coeff):
         k = coeff['k']
         r0 = coeff['r0']
         epsilon = coeff['epsilon']
         sigma = coeff['sigma']
+        delta = coeff['delta']
         lj1 = 4.0 * epsilon * math.pow(sigma, 12.0)
         lj2 = 4.0 * epsilon * math.pow(sigma, 6.0)
 
@@ -171,7 +172,8 @@ class fene(hoomd.md.bond._bond):
             hoomd.context.msg.error("azplugins.bond.fene(): r0 must be non-zero.\n")
             raise ValueError('r0 must be non-zero')
 
-        return _hoomd.make_scalar4(k, r0, lj1, lj2)
+        #return _hoomd.make_scalar4(k, r0, lj1, lj2)
+        return _azplugins.make_fene_bond_params(lj1, lj2,k,r0,delta)
 
 
 class fene24(hoomd.md.bond._bond):

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -120,7 +120,7 @@ class fene(hoomd.md.bond._bond):
     - :math:`r_0` - size parameter ``r0`` (in distance units)
     - :math:`\varepsilon` - repulsive force strength ``epsilon`` (in energy units)
     - :math:`\sigma` - repulsive force interaction distance ``sigma`` (in distance units)
-    - :math:`\delta` - extra shift parameter for FENE bonds ``delta`` (in distance units),default value of ``delta` is zero
+    - :math:`\delta` - extra shift parameter for FENE bonds ``delta`` (in distance units),default value of  is ``delta`` zero
 
     Examples::
 

--- a/azplugins/bond.py
+++ b/azplugins/bond.py
@@ -126,7 +126,7 @@ class fene(hoomd.md.bond._bond):
 
         fene = azplugins.bond.fene()
         fene.bond_coeff.set('polymer', k=30.0, r0=1.5, sigma=1.0, epsilon=2.0, delta=1.8)
-        fene.bond_coeff.set('backbone', k=100.0, r0=1.0, sigma=1.0, epsilon= 2.0, delta=0.0)
+        fene.bond_coeff.set('backbone', k=100.0, r0=1.0, sigma=1.0, epsilon= 2.0)
 
     """
     def __init__(self, name=None):

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -210,6 +210,7 @@ PYBIND11_MODULE(_azplugins, m)
     /* Bond potentials */
     azplugins::detail::export_bond_potential<azplugins::detail::BondEvaluatorDoubleWell>(m, "BondPotentialDoubleWell");
     azplugins::detail::export_bond_potential<azplugins::detail::BondEvaluatorFENE>(m, "BondPotentialFENE");
+    azplugins::detail::export_fene_bond_params(m);
     azplugins::detail::export_bond_potential<azplugins::detail::BondEvaluatorFENEAsh24>(m, "BondPotentialFENEAsh24");
     azplugins::detail::export_ashbaugh_bond_params(m);
 

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -113,6 +113,23 @@ void export_ashbaugh_bond_params(py::module& m)
     m.def("make_ashbaugh_bond_params", &make_ashbaugh_bond_params);
     }
 
+//! Helper function export the FENE-LJ bond potential parameters
+/*!
+* \sa fene_lj_bond_params
+*/
+void export_fene_bond_params(py::module& m)
+    {
+    py::class_<fene_bond_params>(m, "fene_bond_params")
+    .def(py::init<>())
+    .def_readwrite("lj1", &fene_bond_params::lj1)
+    .def_readwrite("lj2", &fene_bond_params::lj2)
+    .def_readwrite("K", &fene_bond_params::K)
+    .def_readwrite("r0", &fene_bond_params::r_0)
+    .def_readwrite("delta", &fene_bond_params::delta)
+    ;
+    m.def("make_fene_bond_params", &make_fene_bond_params);
+    }
+
 //! Helper function export the Ashbaugh-Hatch pair potential parameters
 /*!
 * \sa ashbaugh_params

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -119,13 +119,14 @@ class potential_bond_fene_tests(unittest.TestCase):
 
     # test the calculation of force and potential when delta is non-zero
     def test_potential_delta_nonzero(self):
-        #fene = azplugins.bond.fene()
-        fene = md.bond.fene()
+        fene = azplugins.bond.fene()
         fene.bond_coeff.set('bond', epsilon=1.0, sigma=1.0, k=30,r0=1.5,delta=1.8)
 
         md.integrate.mode_standard(dt=0)
         nve = md.integrate.nve(group = hoomd.group.all())
         hoomd.run(1)
+        #values of F and  U are caluclated using a calculator, by substituting
+        #r0=1.5,delta=1.8,sigma=1.0,epsilon=1.0, with r=1.0
         F = 33.5403726708
         U = 22.5919825123
         f0 = fene.forces[0].force

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -126,8 +126,8 @@ class potential_bond_fene_tests(unittest.TestCase):
         hoomd.run(1)
         #values of F and  U are caluclated using a calculator, by substituting
         #r0=1.5,delta=1.8,sigma=1.0,epsilon=1.0, with r=1.0
-        F = 33.5403726708
-        U = 22.5919825123
+        F = 57.5403726708
+        U = 12.2959912562
         f0 = fene.forces[0].force
         f1 = fene.forces[1].force
         e0 = fene.forces[0].energy

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -126,7 +126,7 @@ class potential_bond_fene_tests(unittest.TestCase):
         hoomd.run(1)
         #values of F and  U are caluclated using a calculator, by substituting
         #r0=1.5,delta=1.8,sigma=1.0,epsilon=1.0, with r=1.0
-        F = 57.5403726708
+        F = -57.5403726708
         U = 12.2959912562
         f0 = fene.forces[0].force
         f1 = fene.forces[1].force
@@ -136,11 +136,11 @@ class potential_bond_fene_tests(unittest.TestCase):
         self.assertAlmostEqual(e0,0.5*U,3)
         self.assertAlmostEqual(e1,0.5*U,3)
 
-        self.assertAlmostEqual(f0[0],F,3)
+        self.assertAlmostEqual(f0[0],-F,3)
         self.assertAlmostEqual(f0[1],0)
         self.assertAlmostEqual(f0[2],0)
 
-        self.assertAlmostEqual(f1[0],-F,3)
+        self.assertAlmostEqual(f1[0],F,3)
         self.assertAlmostEqual(f1[1],0)
         self.assertAlmostEqual(f1[2],0)
 

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -126,7 +126,7 @@ class potential_bond_fene_tests(unittest.TestCase):
         hoomd.run(1)
         #values of F and  U are caluclated using a calculator, by substituting
         #r0=1.5,delta=1.8,sigma=1.0,epsilon=1.0, with r=1.0
-        F = -57.5403726708
+        F = 57.5403726708
         U = 12.2959912562
         f0 = fene.forces[0].force
         f1 = fene.forces[1].force

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -117,6 +117,33 @@ class potential_bond_fene_tests(unittest.TestCase):
         self.assertAlmostEqual(f1[1],0)
         self.assertAlmostEqual(f1[2],0)
 
+    # test the calculation of force and potential when delta is non-zero
+    def test_potential_delta_nonzero(self):
+        #fene = azplugins.bond.fene()
+        fene = md.bond.fene()
+        fene.bond_coeff.set('bond', epsilon=1.0, sigma=1.0, k=30,r0=1.5,delta=1.8)
+
+        md.integrate.mode_standard(dt=0)
+        nve = md.integrate.nve(group = hoomd.group.all())
+        hoomd.run(1)
+        F = 33.5403726708
+        U = 22.5919825123
+        f0 = fene.forces[0].force
+        f1 = fene.forces[1].force
+        e0 = fene.forces[0].energy
+        e1 = fene.forces[1].energy
+
+        self.assertAlmostEqual(e0,0.5*U,3)
+        self.assertAlmostEqual(e1,0.5*U,3)
+
+        self.assertAlmostEqual(f0[0],F,3)
+        self.assertAlmostEqual(f0[1],0)
+        self.assertAlmostEqual(f0[2],0)
+
+        self.assertAlmostEqual(f1[0],-F,3)
+        self.assertAlmostEqual(f1[1],0)
+        self.assertAlmostEqual(f1[2],0)
+
     # test streching beyond maximal bond length of r0
     def test_potential_strech_beyond_r0(self):
         fene = azplugins.bond.fene()

--- a/azplugins/test-py/test_bond_fene.py
+++ b/azplugins/test-py/test_bond_fene.py
@@ -92,8 +92,7 @@ class potential_bond_fene_tests(unittest.TestCase):
 
     # test the calculation of force and potential
     def test_potential(self):
-        #fene = azplugins.bond.fene()
-        fene = md.bond.fene()
+        fene = azplugins.bond.fene()
         fene.bond_coeff.set('bond', epsilon=1.0, sigma=1.0, k=30,r0=1.5)
 
         md.integrate.mode_standard(dt=0)


### PR DESCRIPTION
I have made  changes to the BondEvaluatorFene.h and associated files like module.cc, test_bond_fene.py and bond.py , like you have asked, in order to change the FENE bond potential to V = -0.5*k*R0*R0*ln(1-((r-delta)/R0)^2)