### PR TITLE
Compute center of mass velocity of a group of particles

### DIFF
--- a/azplugins/CMakeLists.txt
+++ b/azplugins/CMakeLists.txt
@@ -34,6 +34,7 @@ endif(NOT HOOMD_EXTERNAL_BUILD)
 set(_${COMPONENT_NAME}_sources
     module.cc
     BounceBackGeometry.cc
+    GroupVelocityCompute.cc
     ImplicitEvaporator.cc
     ImplicitDropletEvaporator.cc
     ImplicitPlaneEvaporator.cc

--- a/azplugins/GroupVelocityCompute.cc
+++ b/azplugins/GroupVelocityCompute.cc
@@ -1,0 +1,110 @@
+// Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021-2022, Auburn University
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+/*!
+ * \file GroupVelocityCompute.cc
+ * \brief Definition of GroupVelocityCompute
+ */
+
+#include "GroupVelocityCompute.h"
+
+namespace azplugins
+{
+
+/*!
+ * \param sysdef System definition
+ * \param group Particle group
+ * \param suffix Suffix to attach to logged quantities
+ */
+GroupVelocityCompute::GroupVelocityCompute(std::shared_ptr<SystemDefinition> sysdef,
+                                           std::shared_ptr<ParticleGroup> group,
+                                           const std::string& suffix)
+    : Compute(sysdef),
+      m_group(group),
+      m_lognames{"vx"+suffix,"vy"+suffix,"vz"+suffix},
+      m_velocity(0,0,0)
+    {
+    }
+
+/*!
+ * \param timestep Simulation timestep
+ *
+ * The center-of-mass velocity of the group is determined by first summing the
+ * momentum and mass of all particles, then dividing momentum by mass. This
+ * compute supports MPI decomposition, and the result is available on all ranks.
+ */
+void GroupVelocityCompute::compute(unsigned int timestep)
+    {
+    if (!shouldCompute(timestep))
+        return;
+
+    // empty group has no velocity, quit early
+    if (m_group->getNumMembersGlobal() == 0)
+        {
+        m_velocity = make_scalar3(0,0,0);
+        return;
+        }
+
+    // accumulate momentum and masses
+    const unsigned int N = m_group->getNumMembers();
+    ArrayHandle<unsigned int> h_index(m_group->getIndexArray(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(), access_location::host, access_mode::read);
+    Scalar4 mom_mass(0,0,0,0);
+    for (unsigned int i=0; i < N; ++i)
+        {
+        const Scalar4 vel_mass = h_vel.data[h_index.data[i]];
+        const Scalar mass = vel_mass.w;
+        mom_mass += make_scalar4(mass*vel_mass.x,mass*vel_mass.y,mass*vel_mass.z,mass);
+        }
+    #ifdef ENABLE_MPI
+    if (m_comm)
+        {
+        Scalar buffer[4] = {mom_mass.x, mom_mass.y, mom_mass.z, mom_mass.w};
+        MPI_Allreduce(MPI_IN_PLACE, &buffer[0], 4, MPI_HOOMD_SCALAR, MPI_SUM, m_exec_conf->getMPICommunicator());
+        mom_mass = make_scalar4(buffer[0],buffer[1],buffer[2],buffer[3]);
+        }
+    #endif // ENABLE_MPI
+
+    // reduce total momentum by mass to get center-of-mass
+    m_velocity = make_scalar3(mom_mass.x,mom_mass.y,mom_mass.z)/mom_mass.w;
+    }
+
+std::vector<std::string> GroupVelocityCompute::getProvidedLogQuantities()
+	{
+	return m_lognames;
+	}
+
+Scalar GroupVelocityCompute::getLogValue(const std::string& quantity, unsigned int timestep)
+    {
+    compute(timestep);
+    if (quantity == m_lognames[0])
+        {
+        return m_velocity.x;
+        }
+    else if (quantity == m_lognames[1])
+        {
+        return m_velocity.y;
+        }
+    else if (quantity == m_lognames[2])
+        {
+        return m_velocity.z;
+        }
+    else
+        {
+        m_exec_conf->msg->error() << "GroupVelocityCompute: " << quantity << " is not a valid log quantity" << endl;
+        throw runtime_error("Unknown log quantity");
+        }
+    }
+    
+namespace detail
+{
+void export_GroupVelocityCompute(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<GroupVelocityCompute,std::shared_ptr<GroupVelocityCompute>,Compute>(m, "GroupVelocityCompute")
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<ParticleGroup>,const std::string&>())
+        ;
+    }
+} // end namespace detail
+} // end namespace azplugins

--- a/azplugins/GroupVelocityCompute.cc
+++ b/azplugins/GroupVelocityCompute.cc
@@ -54,7 +54,7 @@ void GroupVelocityCompute::compute(unsigned int timestep)
     const unsigned int N = m_group->getNumMembers();
     ArrayHandle<unsigned int> h_index(m_group->getIndexArray(), access_location::host, access_mode::read);
     ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(), access_location::host, access_mode::read);
-    Scalar3 momentum = make_scalar3(0.,0.,0.);
+    Scalar3 momentum = make_scalar3(0,0,0);
     Scalar mass(0);
     for (unsigned int i=0; i < N; ++i)
         {

--- a/azplugins/GroupVelocityCompute.h
+++ b/azplugins/GroupVelocityCompute.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2018-2020, Michael P. Howard
+// Copyright (c) 2021-2022, Auburn University
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+/*!
+ * \file GroupVelocityCompute.h
+ * \brief Declaration of GroupVelocityCompute
+ */
+
+#ifndef AZPLUGINS_GROUP_VELOCITY_COMPUTE_H_
+#define AZPLUGINS_GROUP_VELOCITY_COMPUTE_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "hoomd/Compute.h"
+#include "hoomd/HOOMDMath.h"
+#include "hoomd/ParticleGroup.h"
+#include "hoomd/SystemDefinition.h"
+
+#include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+#include <string>
+#include <vector>
+
+namespace azplugins
+{
+//! Compute the center-of-mass velocity of a group of particles
+class PYBIND11_EXPORT GroupVelocityCompute : public Compute
+    {
+    public:
+        //! Constructor
+        GroupVelocityCompute(std::shared_ptr<SystemDefinition> sysdef,
+                             std::shared_ptr<ParticleGroup> group,
+                             const std::string& suffix);
+
+        //! Destructor
+        ~GroupVelocityCompute();
+
+        //! Compute center-of-mass velocity of group
+        void compute(unsigned int timestep) override;
+
+        //! List of logged quantities
+        std::vector<std::string> getProvidedLogQuantities() override;
+
+        //! Return the logged value
+        Scalar getLogValue(const std::string& quantity, unsigned int timestep) override;
+
+    protected:
+        std::shared_ptr<ParticleGroup> m_group; //!< Particle group
+        std::vector<std::string> m_lognames;    //!< Logged quantities
+        Scalar3 m_velocity;                     //!< Last compute velocity
+    };
+
+namespace detail
+{
+//! Exports the GroupVelocityCompute to python
+void export_GroupVelocityCompute(pybind11::module& m);
+} // end namespace detail
+} // end namespace azplugins
+
+#endif // AZPLUGINS_GROUP_VELOCITY_COMPUTE_H_

--- a/azplugins/GroupVelocityCompute.h
+++ b/azplugins/GroupVelocityCompute.h
@@ -35,7 +35,7 @@ class PYBIND11_EXPORT GroupVelocityCompute : public Compute
                              const std::string& suffix);
 
         //! Destructor
-        ~GroupVelocityCompute();
+        virtual ~GroupVelocityCompute();
 
         //! Compute center-of-mass velocity of group
         void compute(unsigned int timestep) override;

--- a/azplugins/analyze.py
+++ b/azplugins/analyze.py
@@ -25,7 +25,7 @@ class group_velocity(hoomd.compute._compute):
     r"""Group center-of-mass velocity compute
 
     Args:
-        group (:py:mod:`hoomd.group.group`): Group to compute velocity of.
+        group (:py:mod:`hoomd.group`): Group to compute velocity of.
         suffix (str): Suffix to attach to logged quantities.
 
     This computes the center-of-mass velocity of a group:
@@ -38,9 +38,16 @@ class group_velocity(hoomd.compute._compute):
     of particle *i* in the group.
 
     The components of the result are exposed as loggable quantities ``vx``,
-    ``vy``, and ``vz`` with ``suffix`` appended. By default, ``suffix`` is the
-    name of the ``group``, but a custom suffix may be specified. You can save
-    these results using :py:class:`hoomd.analyze.log`.
+    ``vy``, and ``vz`` with ``suffix`` appended. By default, ``suffix`` is
+    ``_name`` where ``name`` is the name of the ``group``, like ``_all`` for
+    :py:class:`hoomd.group.all`. However, a custom suffix may be specified; the
+    only requirement is that the same suffix cannot be used more than once. You
+    can save these results using :py:class:`hoomd.analyze.log`.
+
+    Example::
+
+        azplugins.analyze.group_velocity(hoomd.group.all())
+        hoomd.analze.log(filename='velocity.dat', quantities=['vx_all'], period=10)
 
     """
     def __init__(self, group, suffix=None):

--- a/azplugins/analyze.py
+++ b/azplugins/analyze.py
@@ -46,8 +46,17 @@ class group_velocity(hoomd.compute._compute):
 
     Example::
 
+        # all particles
         azplugins.analyze.group_velocity(hoomd.group.all())
-        hoomd.analze.log(filename='velocity.dat', quantities=['vx_all'], period=10)
+        hoomd.analyze.log(filename='velocity.dat', quantities=['vx_all'], period=10)
+
+        # suffix comes from group name
+        azplugins.analyze.group_velocity(hoomd.group.type('A',name='A'))
+        hoomd.analyze.log(filename='velocity_A.dat', quantities=['vx_A'], period=50)
+
+        # suffix is manually set
+        azplugins.analyze.group_velocity(hoomd.group.type('B'), suffix='-big')
+        hoomd.analyze.log(filename='velocity_big.dat', quantities=['vx-big'], period=100)
 
     """
     def __init__(self, group, suffix=None):

--- a/azplugins/analyze.py
+++ b/azplugins/analyze.py
@@ -8,7 +8,10 @@ Analyzers
 .. autosummary::
     :nosignatures:
 
+    group_velocity
     rdf
+
+.. autoclass:: group_velocity
 
 .. autoclass:: rdf
 

--- a/azplugins/analyze.py
+++ b/azplugins/analyze.py
@@ -18,6 +18,51 @@ import hoomd
 
 from . import _azplugins
 
+class group_velocity(hoomd.compute._compute):
+    r"""Group center-of-mass velocity compute
+
+    Args:
+        group (:py:mod:`hoomd.group.group`): Group to compute velocity of.
+        suffix (str): Suffix to attach to logged quantities.
+
+    This computes the center-of-mass velocity of a group:
+
+    .. math::
+
+        \mathbf{v}_{\rm cm} = \dfrac{\sum_i m_i \mathbf{v}_i}{\sum_i m_i}
+
+    where :math:`\mathbf{v}_i` is the velocity and and :math:`m_i` is the mass
+    of particle *i* in the group.
+
+    The components of the result are exposed as loggable quantities ``vx``,
+    ``vy``, and ``vz`` with ``suffix`` appended. By default, ``suffix`` is the
+    name of the ``group``, but a custom suffix may be specified. You can save
+    these results using :py:class:`hoomd.analyze.log`.
+
+    """
+    def __init__(self, group, suffix=None):
+        hoomd.util.print_status_line()
+        super().__init__()
+
+        # group object
+        self.group = group
+
+        # create suffix for logged quantity
+        if suffix is None:
+            suffix = '_' + group.name
+
+        if suffix in self._used_suffixes:
+            hoomd.context.msg.error('azplugins.analyze.group_velocity: Suffix {} already used\n'.format(suffix))
+            raise ValueError('Suffix {} already used for group velocity'.format(suffix))
+        else:
+            self._used_suffixes.append(suffix)
+
+        # create the c++ mirror class
+        self.cpp_compute = _azplugins.GroupVelocityCompute(hoomd.context.current.system_definition, group.cpp_group, suffix)
+        hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name);
+
+    _used_suffixes = []
+
 class rdf(hoomd.analyze._analyzer):
     R""" Radial distribution function calculator
 

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -59,6 +59,7 @@ namespace py = pybind11;
 #endif // ENABLE_CUDA
 
 /* Analyzers */
+#include "GroupVelocityCompute.h"
 #include "RDFAnalyzer.h"
 #ifdef ENABLE_CUDA
 #include "RDFAnalyzerGPU.h"
@@ -275,6 +276,7 @@ PYBIND11_MODULE(_azplugins, m)
     #endif // ENABLE_MPCD
 
     /* Analyzers */
+    azplugins::detail::export_GroupVelocityCompute(m);
     azplugins::detail::export_RDFAnalyzer(m);
     #ifdef ENABLE_CUDA
     azplugins::detail::export_RDFAnalyzerGPU(m);

--- a/azplugins/test-py/CMakeLists.txt
+++ b/azplugins/test-py/CMakeLists.txt
@@ -3,6 +3,7 @@
 # This file is part of the azplugins project, released under the Modified BSD License.
 
 set(TEST_LIST_CPU
+    test_analyze_group_velocity
     test_analyze_rdf
     test_bond_double_well
     test_bond_fene

--- a/azplugins/test-py/test_analyze_group_velocity.py
+++ b/azplugins/test-py/test_analyze_group_velocity.py
@@ -47,6 +47,12 @@ class analyze_group_velocity_tests(unittest.TestCase):
         v = [log.query('vx_foo'), log.query('vy_foo'), log.query('vz_foo')]
         np.testing.assert_allclose(v, [-2,4,-6])
 
+    def test_unique_suffix(self):
+        all_ = hoomd.group.all()
+        azplugins.analyze.group_velocity(group=all_,suffix='_1')
+        with self.assertRaises(ValueError):
+            azplugins.analyze.group_velocity(group=all_,suffix='_1')
+
     def tearDown(self):
         del self.s
         hoomd.context.initialize()

--- a/azplugins/test-py/test_analyze_group_velocity.py
+++ b/azplugins/test-py/test_analyze_group_velocity.py
@@ -39,6 +39,14 @@ class analyze_group_velocity_tests(unittest.TestCase):
         v = [log.query('vx_A'), log.query('vy_A'), log.query('vz_A')]
         np.testing.assert_allclose(v, [1,-2,3])
 
+    def test_compute_empty_group(self):
+        notatype = hoomd.group.type('C')
+        azplugins.analyze.group_velocity(group=notatype)
+        log = hoomd.analyze.log(filename=None, quantities=['vx_C','vy_C','vz_C'], period=1)
+        hoomd.run(1)
+        v = [log.query('vx_C'), log.query('vy_C'), log.query('vz_C')]
+        np.testing.assert_allclose(v, [0,0,0])
+
     def test_compute_suffix(self):
         typeB = hoomd.group.type('B',name='B')
         azplugins.analyze.group_velocity(group=typeB,suffix='_foo')

--- a/azplugins/test-py/test_analyze_group_velocity.py
+++ b/azplugins/test-py/test_analyze_group_velocity.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021-2022, Auburn University
+# This file is part of the azplugins project, released under the Modified BSD License.
+
+import hoomd
+from hoomd import md
+hoomd.context.initialize()
+try:
+    from hoomd import azplugins
+except ImportError:
+    import azplugins
+import unittest
+import numpy as np
+
+class analyze_group_velocity_tests(unittest.TestCase):
+    def setUp(self):
+        snap = hoomd.data.make_snapshot(N=2, box=hoomd.data.boxdim(Lx=10,Ly=10,Lz=10), particle_types=['A','B'])
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.position[:] = [[0,0,-5],[0,0,5]]
+            snap.particles.velocity[:] = [[1,-2,3],[-2,4,-6]]
+            snap.particles.typeid[:] = [0,1]
+            snap.particles.mass[:] = [1,2]
+
+        self.s = hoomd.init.read_snapshot(snap)
+
+    def test_compute_all(self):
+        all_ = hoomd.group.all()
+        azplugins.analyze.group_velocity(group=all_)
+        log = hoomd.analyze.log(filename=None, quantities=['vx_all','vy_all','vz_all'], period=1)
+        hoomd.run(1)
+        v = [log.query('vx_all'), log.query('vy_all'), log.query('vz_all')]
+        np.testing.assert_allclose(v, [-1,2,-3])
+
+    def test_compute_subset(self):
+        typeA = hoomd.group.type('A',name='A')
+        azplugins.analyze.group_velocity(group=typeA)
+        log = hoomd.analyze.log(filename=None, quantities=['vx_A','vy_A','vz_A'], period=1)
+        hoomd.run(1)
+        v = [log.query('vx_A'), log.query('vy_A'), log.query('vz_A')]
+        np.testing.assert_allclose(v, [1,-2,3])
+
+    def test_compute_suffix(self):
+        typeB = hoomd.group.type('B',name='B')
+        azplugins.analyze.group_velocity(group=typeB,suffix='_foo')
+        log = hoomd.analyze.log(filename=None, quantities=['vx_foo','vy_foo','vz_foo'], period=1)
+        hoomd.run(1)
+        v = [log.query('vx_foo'), log.query('vy_foo'), log.query('vz_foo')]
+        np.testing.assert_allclose(v, [-2,4,-6])
+
+    def tearDown(self):
+        del self.s
+        hoomd.context.initialize()
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])


### PR DESCRIPTION
This PR implements a CPU compute to add up the velocity of a group of particles. This is useful in MPI simulations because it bypasses needing to pull a snapshot onto the root rank in python. It could be implemented on the GPU too using `thrust::transform_reduce`, but I don't have a GPU for testing and don't need it right now.