### PR TITLE
Refactor/flow profile

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,6 +20,7 @@ tested against v4.7.0 of HOOMD-blue.
     module-azplugins-bond
     module-azplugins-flow
     module-azplugins-pair
+    module-azplugins-compute
 
 Index
 =====

--- a/doc/module-azplugins-compute.rst
+++ b/doc/module-azplugins-compute.rst
@@ -1,0 +1,23 @@
+.. Copyright (c) 2018-2020, Michael P. Howard
+.. Copyright (c) 2021-2024, Auburn University
+.. Part of azplugins, released under the BSD 3-Clause License.
+
+azplugins.compute
+-----------------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.azplugins.compute
+
+.. autosummary::
+    :nosignatures:
+
+    FlowProfile
+
+.. rubric:: Details
+
+.. automodule:: hoomd.azplugins.compute
+    :synopsis: Compute operations.
+    :members: FlowProfile
+    :no-inherited-members:
+    :show-inheritance:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(_${COMPONENT_NAME}_cu_sources
 set(python_files
     __init__.py
     conftest.py
+    compute.py
     bond.py
     flow.py
     pair.py

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,4 +6,6 @@
 
 from hoomd.azplugins import bond, flow, pair
 
+from .compute import FlowProfile
+
 __version__ = '1.0.0'

--- a/src/compute.py
+++ b/src/compute.py
@@ -4,58 +4,63 @@
 
 """Flow profiles."""
 
-import hoomd
-from hoomd import _hoomd
-from hoomd.operation import Compute
-from hoomd.logging import log
-import numpy as np
+import numpy
 from hoomd.data.parameterdicts import ParameterDict
+from hoomd.logging import log
+from hoomd.operation import Compute
+
 
 class FlowProfile(Compute):
-    R"""Measure average profiles along a spatial dimension.
+    """Measure average profiles along a spatial dimension.
 
     The average density, velocity, and temperature profiles are computed along
-    a given spatial dimension. Both number and mass densities and velocities are
-    available.
+    a given spatial dimension. Both number and mass densities and velocities
+    are available.
 
     Args:
-        system (hoomd.Simulation): The HOOMD simulation object containing the system state.
+        system (hoomd.Simulation): The HOOMD simulation object containing the
+            system state.
         axis (int): direction for binning (0=*x*, 1=*y*, 2=*z*).
         bins (int): Number of bins to use along ``axis``.
-        range (tuple): Lower and upper spatial bounds to use along ``axis`` like ``(lo,hi)``.
-        area (float): Cross-sectional area of bins to normalize density  (default: 1.0).
+        range (tuple): Lower and upper spatial bounds to use along ``axis`` like
+            ``(lo,hi)``.
+        area (float): Cross-sectional area of bins to normalize density
+            (default: 1.0).
 
     Examples::
 
-        flow_profile = hoomd.azplugins.compute.FlowProfile(system=sim.state, axis=2, bins=20, range=(-10, 10), area=100)
+        flow_profile = hoomd.azplugins.compute.FlowProfile(
+            system=sim.state, axis=2, bins=20, range=(-10, 10), area=100)
         sim.operations.computes.append(flow_profile)
         sim.run(1e4)
         if sim.device.communicator.rank == 0:
-            np.savetxt('profiles.dat', np.column_stack((flow_profile.centers, flow_profile.number_density, flow_profile.number_velocity[:, 2], flow_profile.kT)))
+            numpy.savetxt('profiles.dat', numpy.column_stack((
+                flow_profile.centers, flow_profile.number_density,
+                flow_profile.number_velocity[:, 2], flow_profile.kT)))
     """
 
-    def __init__(self, system, axis, bins, range, area=1.0):
+    def __init__(self, system, axis, bins, range_, area=1.0):
         super().__init__()
         param_dict = ParameterDict(
             system=system,
             axis=int(axis),
             bins=int(bins),
-            range=tuple(range),
-            area=float(area)
+            range=tuple(range_),
+            area=float(area),
         )
         self._param_dict.update(param_dict)
-        
-        self.edges = np.linspace(range[0], range[1], bins + 1)
+
+        self.edges = numpy.linspace(range_[0], range_[1], bins + 1)
         self.centers = 0.5 * (self.edges[:-1] + self.edges[1:])
         self._dx = self.edges[1:] - self.edges[:-1]
         self.reset()
-        
+
         if self.axis not in (0, 1, 2):
-            raise ValueError('Axis not recognized.')
-        
+            msg = 'Axis not recognized.'
+            raise ValueError(msg)
 
     def __call__(self, timestep):
-
+        """Compute the flow profile at the given timestep."""
         state = self._simulation.state
 
         if self._simulation.device.communicator.rank == 0:
@@ -67,81 +72,84 @@ class FlowProfile(Compute):
             v = velocities
             m = masses
 
-            binids = np.digitize(x, self.edges) - 1
-            flags = np.logical_and(binids >= 0, binids < self.bins)
+            binids = numpy.digitize(x, self.edges) - 1
+            flags = numpy.logical_and(binids >= 0, binids < self.bins)
             binids = binids[flags]
             x = x[flags]
             v = v[flags]
             m = m[flags]
 
-            counts = np.bincount(binids, minlength=self.bins)
+            counts = numpy.bincount(binids, minlength=self.bins)
             self._counts += counts
 
-            mass = np.bincount(binids, weights=m, minlength=self.bins)
+            mass = numpy.bincount(binids, weights=m, minlength=self.bins)
             self._bin_mass += mass
 
-            num_vel = np.zeros((self.bins, 3))
-            mass_vel = np.zeros((self.bins, 3))
+            num_vel = numpy.zeros((self.bins, 3))
+            mass_vel = numpy.zeros((self.bins, 3))
             for dim in range(3):
-                num_vel[:, dim] = np.bincount(binids, weights=v[:, dim], minlength=self.bins)
-                mass_vel[:, dim] = np.bincount(binids, weights=m * v[:, dim], minlength=self.bins)
-            np.divide(num_vel, counts[:, None], out=num_vel, where=counts[:, None] > 0)
-            np.divide(mass_vel, mass[:, None], out=mass_vel, where=mass[:, None] > 0)
+                num_vel[:, dim] = numpy.bincount(
+                    binids, weights=v[:, dim], minlength=self.bins
+                )
+                mass_vel[:, dim] = numpy.bincount(
+                    binids, weights=m * v[:, dim], minlength=self.bins
+                )
+            numpy.divide(
+                num_vel, counts[:, None], out=num_vel, where=counts[:, None] > 0
+            )
+            numpy.divide(mass_vel, mass[:, None], out=mass_vel, where=mass[:, None] > 0)
             self._number_velocity += num_vel
             self._mass_velocity += mass_vel
 
-            ke = np.bincount(binids, weights=0.5 * m * np.sum(v ** 2, axis=1), minlength=self.bins)
-            ke_cm = 0.5 * mass * np.sum(mass_vel ** 2, axis=1)
-            kT = np.zeros(self.bins)
-            np.divide(2 * (ke - ke_cm), 3 * (counts - 1), out=kT, where=counts > 1)
+            ke = numpy.bincount(
+                binids, weights=0.5 * m * numpy.sum(v**2, axis=1), minlength=self.bins
+            )
+            ke_cm = 0.5 * mass * numpy.sum(mass_vel**2, axis=1)
+            kT = numpy.zeros(self.bins)
+            numpy.divide(2 * (ke - ke_cm), 3 * (counts - 1), out=kT, where=counts > 1)
             self._kT += kT
             self.samples += 1
 
     def reset(self):
         """Reset the internal averaging counters."""
         self.samples = 0
-        self._counts = np.zeros(self.bins)
-        self._bin_mass = np.zeros(self.bins)
-        self._number_velocity = np.zeros((self.bins, 3))
-        self._mass_velocity = np.zeros((self.bins, 3))
-        self._kT = np.zeros(self.bins)
+        self._counts = numpy.zeros(self.bins)
+        self._bin_mass = numpy.zeros(self.bins)
+        self._number_velocity = numpy.zeros((self.bins, 3))
+        self._mass_velocity = numpy.zeros((self.bins, 3))
+        self._kT = numpy.zeros(self.bins)
 
     @log(category='sequence')
     def number_density(self):
-        r"""The current average number density profile."""
+        """Return the number density."""
         if self._simulation.device.communicator.rank == 0 and self.samples > 0:
             return self._counts / (self._dx * self.area * self.samples)
-        else:
-            return None
+        return None
 
     @log(category='sequence')
     def mass_density(self):
-        r"""The current mass-averaged density profile."""
+        """Return the mass density."""
         if self._simulation.device.communicator.rank == 0 and self.samples > 0:
             return self._bin_mass / (self._dx * self.area * self.samples)
-        else:
-            return None
+        return None
 
     @log(category='sequence')
     def number_velocity(self):
-        r"""The current number-averaged velocity profile."""
+        """Return the number velocity."""
         if self._simulation.device.communicator.rank == 0 and self.samples > 0:
             return self._number_velocity / self.samples
-        else:
-            return None
+        return None
 
     @log(category='sequence')
     def mass_velocity(self):
-        r"""The current mass-averaged velocity profile."""
+        """Return the mass velocity."""
         if self._simulation.device.communicator.rank == 0 and self.samples > 0:
             return self._mass_velocity / self.samples
-        else:
-            return None
+        return None
 
     @log(category='sequence')
-    def kT(self):
-        r"""The current average temperature profile."""
+    def kt(self):
+        """Return the temperature (kT)."""
         if self._simulation.device.communicator.rank == 0 and self.samples > 0:
             return self._kT / self.samples
-        else:
-            return None
+        return None

--- a/src/compute.py
+++ b/src/compute.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021-2024, Auburn University
+# Part of azplugins, released under the BSD 3-Clause License.
+
+"""Flow profiles."""
+
+import hoomd
+from hoomd import _hoomd
+from hoomd.operation import Compute
+from hoomd.logging import log
+import numpy as np
+from hoomd.data.parameterdicts import ParameterDict
+
+class FlowProfile(Compute):
+    R"""Measure average profiles along a spatial dimension.
+
+    The average density, velocity, and temperature profiles are computed along
+    a given spatial dimension. Both number and mass densities and velocities are
+    available.
+
+    Args:
+        system (hoomd.Simulation): The HOOMD simulation object containing the system state.
+        axis (int): direction for binning (0=*x*, 1=*y*, 2=*z*).
+        bins (int): Number of bins to use along ``axis``.
+        range (tuple): Lower and upper spatial bounds to use along ``axis`` like ``(lo,hi)``.
+        area (float): Cross-sectional area of bins to normalize density  (default: 1.0).
+
+    Examples::
+
+        flow_profile = hoomd.azplugins.compute.FlowProfile(system=sim.state, axis=2, bins=20, range=(-10, 10), area=100)
+        sim.operations.computes.append(flow_profile)
+        sim.run(1e4)
+        if sim.device.communicator.rank == 0:
+            np.savetxt('profiles.dat', np.column_stack((flow_profile.centers, flow_profile.number_density, flow_profile.number_velocity[:, 2], flow_profile.kT)))
+    """
+
+    def __init__(self, system, axis, bins, range, area=1.0):
+        super().__init__()
+        param_dict = ParameterDict(
+            system=system,
+            axis=int(axis),
+            bins=int(bins),
+            range=tuple(range),
+            area=float(area)
+        )
+        self._param_dict.update(param_dict)
+        
+        self.edges = np.linspace(range[0], range[1], bins + 1)
+        self.centers = 0.5 * (self.edges[:-1] + self.edges[1:])
+        self._dx = self.edges[1:] - self.edges[:-1]
+        self.reset()
+        
+        if self.axis not in (0, 1, 2):
+            raise ValueError('Axis not recognized.')
+        
+
+    def __call__(self, timestep):
+
+        state = self._simulation.state
+
+        if self._simulation.device.communicator.rank == 0:
+            positions = state.get_snapshot().particles.position
+            velocities = state.get_snapshot().particles.velocity
+            masses = state.get_snapshot().particles.mass
+
+            x = positions[:, self.axis]
+            v = velocities
+            m = masses
+
+            binids = np.digitize(x, self.edges) - 1
+            flags = np.logical_and(binids >= 0, binids < self.bins)
+            binids = binids[flags]
+            x = x[flags]
+            v = v[flags]
+            m = m[flags]
+
+            counts = np.bincount(binids, minlength=self.bins)
+            self._counts += counts
+
+            mass = np.bincount(binids, weights=m, minlength=self.bins)
+            self._bin_mass += mass
+
+            num_vel = np.zeros((self.bins, 3))
+            mass_vel = np.zeros((self.bins, 3))
+            for dim in range(3):
+                num_vel[:, dim] = np.bincount(binids, weights=v[:, dim], minlength=self.bins)
+                mass_vel[:, dim] = np.bincount(binids, weights=m * v[:, dim], minlength=self.bins)
+            np.divide(num_vel, counts[:, None], out=num_vel, where=counts[:, None] > 0)
+            np.divide(mass_vel, mass[:, None], out=mass_vel, where=mass[:, None] > 0)
+            self._number_velocity += num_vel
+            self._mass_velocity += mass_vel
+
+            ke = np.bincount(binids, weights=0.5 * m * np.sum(v ** 2, axis=1), minlength=self.bins)
+            ke_cm = 0.5 * mass * np.sum(mass_vel ** 2, axis=1)
+            kT = np.zeros(self.bins)
+            np.divide(2 * (ke - ke_cm), 3 * (counts - 1), out=kT, where=counts > 1)
+            self._kT += kT
+            self.samples += 1
+
+    def reset(self):
+        """Reset the internal averaging counters."""
+        self.samples = 0
+        self._counts = np.zeros(self.bins)
+        self._bin_mass = np.zeros(self.bins)
+        self._number_velocity = np.zeros((self.bins, 3))
+        self._mass_velocity = np.zeros((self.bins, 3))
+        self._kT = np.zeros(self.bins)
+
+    @log(category='sequence')
+    def number_density(self):
+        r"""The current average number density profile."""
+        if self._simulation.device.communicator.rank == 0 and self.samples > 0:
+            return self._counts / (self._dx * self.area * self.samples)
+        else:
+            return None
+
+    @log(category='sequence')
+    def mass_density(self):
+        r"""The current mass-averaged density profile."""
+        if self._simulation.device.communicator.rank == 0 and self.samples > 0:
+            return self._bin_mass / (self._dx * self.area * self.samples)
+        else:
+            return None
+
+    @log(category='sequence')
+    def number_velocity(self):
+        r"""The current number-averaged velocity profile."""
+        if self._simulation.device.communicator.rank == 0 and self.samples > 0:
+            return self._number_velocity / self.samples
+        else:
+            return None
+
+    @log(category='sequence')
+    def mass_velocity(self):
+        r"""The current mass-averaged velocity profile."""
+        if self._simulation.device.communicator.rank == 0 and self.samples > 0:
+            return self._mass_velocity / self.samples
+        else:
+            return None
+
+    @log(category='sequence')
+    def kT(self):
+        r"""The current average temperature profile."""
+        if self._simulation.device.communicator.rank == 0 and self.samples > 0:
+            return self._kT / self.samples
+        else:
+            return None

--- a/src/pytest/CMakeLists.txt
+++ b/src/pytest/CMakeLists.txt
@@ -6,6 +6,7 @@ set(test_files
     test_pair.py
     test_pair_aniso.py
     test_pair_dpd.py
+    test_flow_profile.py
     )
 
 # Copy tests to the install directory.

--- a/src/pytest/test_flow_profile.py
+++ b/src/pytest/test_flow_profile.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2018-2020, Michael P. Howard
+# Copyright (c) 2021-2022, Auburn University
+# This file is part of the azplugins project, released under the Modified BSD License.
+
+import hoomd
+import hoomd.azplugins
+import numpy as np
+import pytest
+from hoomd.azplugins.compute import FlowProfile
+
+class TestFlowProfile:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        device = hoomd.device.auto_select()
+        self.sim = hoomd.Simulation(device=device, seed=42)
+        L = 10.0
+        snapshot = hoomd.Snapshot()
+        if snapshot.communicator.rank == 0:
+            snapshot.configuration.box = [L, L, L, 0, 0, 0]
+            snapshot.particles.N = 5
+            snapshot.particles.types = ['A', 'B', 'C']
+            snapshot.particles.position[:] = [[0, 0, -4.25], [0, 0, 2.25], [0, 0, 3.0], [0, 0, 4.25], [0, 0, 4.2]]
+            snapshot.particles.velocity[:] = [[2.0, 0, 0], [1.0, 0, 0], [-1.0, 0, 0], [3.0, 0, 0], [1.0, 0, 0]]
+            snapshot.particles.mass[:] = [0.5, 0.5, 0.5, 0.5, 1.0]
+
+        self.sim.create_state_from_snapshot(snapshot)
+        integrator = hoomd.md.Integrator(dt=0.001)
+        
+        nl = hoomd.md.nlist.Cell(buffer=0.4)
+        lj = hoomd.md.pair.LJ(nlist=nl, default_r_cut=2.5)
+        
+        # Setting LJ parameters for all type pairs
+        lj.params[('A', 'A')] = dict(epsilon=1.0, sigma=1.0)
+        lj.params[('A', 'B')] = dict(epsilon=1.0, sigma=1.0)
+        lj.params[('A', 'C')] = dict(epsilon=1.0, sigma=1.0)
+        lj.params[('B', 'B')] = dict(epsilon=1.0, sigma=1.0)
+        lj.params[('B', 'C')] = dict(epsilon=1.0, sigma=1.0)
+        lj.params[('C', 'C')] = dict(epsilon=1.0, sigma=1.0)
+
+        integrator.forces.append(lj)
+        self.sim.operations.integrator = integrator
+
+        self.flow_profile = FlowProfile(system=self.sim.state, axis=2, bins=10, range=(-5, 5), area=10**2)
+        self.sim.operations.computes.append(self.flow_profile)
+
+    def test_binning(self):
+        self.sim.run(1)
+        
+        self.flow_profile(self.sim.timestep)
+
+        expected_bins = np.linspace(-5, 5, 11)
+        np.testing.assert_allclose(self.flow_profile.edges, expected_bins)
+        expected_centers = 0.5 * (expected_bins[:-1] + expected_bins[1:])
+        np.testing.assert_allclose(self.flow_profile.centers, expected_centers)
+
+        bin_volume = 10 * 10 * 1.0
+        expected_densities = np.array([1, 0, 0, 0, 0, 0, 0, 1, 1, 2]) / bin_volume
+        np.testing.assert_allclose(self.flow_profile.number_density, expected_densities)
+
+        expected_velocities = [
+            [2, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], 
+            [1, 0, 0], [-1, 0, 0], [(3.0 + 1.0) / 2, 0, 0]
+        ]
+        np.testing.assert_allclose(self.flow_profile.number_velocity, expected_velocities)
+
+    def test_mass_averaging(self):
+        self.sim.run(1)
+        
+        self.flow_profile(self.sim.timestep)
+
+        bin_volume = 10 * 10 * 1.0
+        expected_densities = np.array([0.5, 0, 0, 0, 0, 0, 0, 0.5, 0.5, 1 + 0.5]) / bin_volume
+        np.testing.assert_allclose(self.flow_profile.mass_density, expected_densities)
+
+        expected_velocities = [
+            [2, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
+            [1, 0, 0], [-1, 0, 0], [(3.0 * 0.5 + 1.0 * 1.0) / (0.5 + 1.0), 0, 0]
+        ]
+        np.testing.assert_allclose(self.flow_profile.mass_velocity, expected_velocities)
+
+    def test_temperature(self):
+        self.sim.run(1)
+        
+        self.flow_profile(self.sim.timestep)
+
+        expected_temperature = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0.444444444])
+        np.testing.assert_allclose(self.flow_profile.kT, expected_temperature)
+
+    def test_missing_params(self):
+        with pytest.raises(TypeError):
+            FlowProfile(system=self.sim.state, bins=10.5, range=(-5, 5), area=10**2)
+        with pytest.raises(ValueError):
+            FlowProfile(system=self.sim.state, axis=3.0, bins=10, range=(-5, 5), area=10**2)
+        with pytest.raises(TypeError):
+            FlowProfile(system=self.sim.state, axis='x')
+        with pytest.raises(TypeError):
+            FlowProfile(system=self.sim.state)
+        with pytest.raises(ValueError):
+            FlowProfile(system=self.sim.state, axis=28, bins=10, range=(-5, 5))
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/src/pytest/test_flow_profile.py
+++ b/src/pytest/test_flow_profile.py
@@ -1,16 +1,22 @@
 # Copyright (c) 2018-2020, Michael P. Howard
-# Copyright (c) 2021-2022, Auburn University
-# This file is part of the azplugins project, released under the Modified BSD License.
+# Copyright (c) 2021-2024, Auburn University
+# Part of azplugins, released under the BSD 3-Clause License.
+
+"""Tests for the FlowProfile class."""
 
 import hoomd
 import hoomd.azplugins
-import numpy as np
+import numpy
 import pytest
 from hoomd.azplugins.compute import FlowProfile
 
+
 class TestFlowProfile:
+    """Tests for the FlowProfile class."""
+
     @pytest.fixture(autouse=True)
-    def setUp(self):
+    def _setup(self):
+        """Fixture setup for each test."""
         device = hoomd.device.auto_select()
         self.sim = hoomd.Simulation(device=device, seed=42)
         L = 10.0
@@ -19,16 +25,28 @@ class TestFlowProfile:
             snapshot.configuration.box = [L, L, L, 0, 0, 0]
             snapshot.particles.N = 5
             snapshot.particles.types = ['A', 'B', 'C']
-            snapshot.particles.position[:] = [[0, 0, -4.25], [0, 0, 2.25], [0, 0, 3.0], [0, 0, 4.25], [0, 0, 4.2]]
-            snapshot.particles.velocity[:] = [[2.0, 0, 0], [1.0, 0, 0], [-1.0, 0, 0], [3.0, 0, 0], [1.0, 0, 0]]
+            snapshot.particles.position[:] = [
+                [0, 0, -4.25],
+                [0, 0, 2.25],
+                [0, 0, 3.0],
+                [0, 0, 4.25],
+                [0, 0, 4.2],
+            ]
+            snapshot.particles.velocity[:] = [
+                [2.0, 0, 0],
+                [1.0, 0, 0],
+                [-1.0, 0, 0],
+                [3.0, 0, 0],
+                [1.0, 0, 0],
+            ]
             snapshot.particles.mass[:] = [0.5, 0.5, 0.5, 0.5, 1.0]
 
         self.sim.create_state_from_snapshot(snapshot)
         integrator = hoomd.md.Integrator(dt=0.001)
-        
+
         nl = hoomd.md.nlist.Cell(buffer=0.4)
         lj = hoomd.md.pair.LJ(nlist=nl, default_r_cut=2.5)
-        
+
         # Setting LJ parameters for all type pairs
         lj.params[('A', 'A')] = dict(epsilon=1.0, sigma=1.0)
         lj.params[('A', 'B')] = dict(epsilon=1.0, sigma=1.0)
@@ -40,63 +58,98 @@ class TestFlowProfile:
         integrator.forces.append(lj)
         self.sim.operations.integrator = integrator
 
-        self.flow_profile = FlowProfile(system=self.sim.state, axis=2, bins=10, range=(-5, 5), area=10**2)
+        self.flow_profile = FlowProfile(
+            system=self.sim.state, axis=2, bins=10, range=(-5, 5), area=10**2
+        )
         self.sim.operations.computes.append(self.flow_profile)
 
     def test_binning(self):
+        """Test binning functionality."""
         self.sim.run(1)
-        
+
         self.flow_profile(self.sim.timestep)
 
-        expected_bins = np.linspace(-5, 5, 11)
-        np.testing.assert_allclose(self.flow_profile.edges, expected_bins)
+        expected_bins = numpy.linspace(-5, 5, 11)
+        numpy.testing.assert_allclose(self.flow_profile.edges, expected_bins)
         expected_centers = 0.5 * (expected_bins[:-1] + expected_bins[1:])
-        np.testing.assert_allclose(self.flow_profile.centers, expected_centers)
+        numpy.testing.assert_allclose(self.flow_profile.centers, expected_centers)
 
         bin_volume = 10 * 10 * 1.0
-        expected_densities = np.array([1, 0, 0, 0, 0, 0, 0, 1, 1, 2]) / bin_volume
-        np.testing.assert_allclose(self.flow_profile.number_density, expected_densities)
+        expected_densities = numpy.array([1, 0, 0, 0, 0, 0, 0, 1, 1, 2]) / bin_volume
+        numpy.testing.assert_allclose(
+            self.flow_profile.number_density, expected_densities
+        )
 
         expected_velocities = [
-            [2, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], 
-            [1, 0, 0], [-1, 0, 0], [(3.0 + 1.0) / 2, 0, 0]
+            [2, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [-1, 0, 0],
+            [(3.0 + 1.0) / 2, 0, 0],
         ]
-        np.testing.assert_allclose(self.flow_profile.number_velocity, expected_velocities)
+        numpy.testing.assert_allclose(
+            self.flow_profile.number_velocity, expected_velocities
+        )
 
     def test_mass_averaging(self):
+        """Test mass averaging functionality."""
         self.sim.run(1)
-        
+
         self.flow_profile(self.sim.timestep)
 
         bin_volume = 10 * 10 * 1.0
-        expected_densities = np.array([0.5, 0, 0, 0, 0, 0, 0, 0.5, 0.5, 1 + 0.5]) / bin_volume
-        np.testing.assert_allclose(self.flow_profile.mass_density, expected_densities)
+        expected_densities = (
+            numpy.array([0.5, 0, 0, 0, 0, 0, 0, 0.5, 0.5, 1 + 0.5]) / bin_volume
+        )
+        numpy.testing.assert_allclose(
+            self.flow_profile.mass_density, expected_densities
+        )
 
         expected_velocities = [
-            [2, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-            [1, 0, 0], [-1, 0, 0], [(3.0 * 0.5 + 1.0 * 1.0) / (0.5 + 1.0), 0, 0]
+            [2, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [-1, 0, 0],
+            [(3.0 * 0.5 + 1.0 * 1.0) / (0.5 + 1.0), 0, 0],
         ]
-        np.testing.assert_allclose(self.flow_profile.mass_velocity, expected_velocities)
+        numpy.testing.assert_allclose(
+            self.flow_profile.mass_velocity, expected_velocities
+        )
 
     def test_temperature(self):
+        """Test temperature calculation functionality."""
         self.sim.run(1)
-        
+
         self.flow_profile(self.sim.timestep)
 
-        expected_temperature = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0.444444444])
-        np.testing.assert_allclose(self.flow_profile.kT, expected_temperature)
+        expected_temperature = numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0.444444444])
+        numpy.testing.assert_allclose(self.flow_profile.kT, expected_temperature)
 
     def test_missing_params(self):
-        with pytest.raises(TypeError):
+        """Test missing parameters and invalid values."""
+        with pytest.raises(TypeError, match='missing 1 required positional argument'):
             FlowProfile(system=self.sim.state, bins=10.5, range=(-5, 5), area=10**2)
-        with pytest.raises(ValueError):
-            FlowProfile(system=self.sim.state, axis=3.0, bins=10, range=(-5, 5), area=10**2)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match='Axis not recognized'):
+            FlowProfile(
+                system=self.sim.state, axis=3.0, bins=10, range=(-5, 5), area=10**2
+            )
+        with pytest.raises(TypeError, match="must be str, not 'int'"):
             FlowProfile(system=self.sim.state, axis='x')
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match='missing 1 required positional argument'):
             FlowProfile(system=self.sim.state)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Axis not recognized'):
             FlowProfile(system=self.sim.state, axis=28, bins=10, range=(-5, 5))
+
 
 if __name__ == '__main__':
     pytest.main(['-v', __file__])


### PR DESCRIPTION
Add compute.py with class FlowProfile to calculate flow profiles throughout the simulation
Update documentation
Added new test_flow_profile pytest.
Tested with hoomd-4.8.0 and working

*Fix import issues
*Fix sorting order of imports for compute.py and test_flow_profile.py
*Fix formatting issues